### PR TITLE
fix build command build.sh execute perm

### DIFF
--- a/.radi/commands.yml
+++ b/.radi/commands.yml
@@ -5,6 +5,7 @@ build:
   hostname: "build"
   working_dir: /app
   entrypoint:
+    - /bin/sh
     - /app/build.sh
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/.radi/init.yml
+++ b/.radi/init.yml
@@ -17,6 +17,7 @@
       hostname: "build"
       working_dir: /app
       entrypoint:
+        - /bin/sh
         - /app/build.sh
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
This patch changes the build command build.sh to run the script through /bin/sh.

This is needed in cases where the build.sh does not keep executable permissions, such as when it is copied using radi local.project.create.
