### PR TITLE
fix bad yml in docker-compose yml

### DIFF
--- a/.radi/init.yml
+++ b/.radi/init.yml
@@ -438,7 +438,7 @@
       www:
         image: quay.io/wunder/fuzzy-alpine-nginx-pagespeed-drupal
         ports:
-          8081:80
+          - 8081:80
         volumes_from:
           - source
           - assets
@@ -453,7 +453,7 @@
       varnish:
         image: quay.io/wunder/fuzzy-alpine-varnish
         ports:
-          8080:80
+          - 8080:80
         environment:
           DNSDOCK_ALIAS: wundertest.docker
           VARNISH_BACKEND_HOST: backend.app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
   www:
     image: quay.io/wunder/fuzzy-alpine-nginx-pagespeed-drupal
     ports:
-      8081:80
+      - 8081:80
     volumes_from:
       - source
       - assets
@@ -77,7 +77,7 @@ services:
   varnish:
     image: quay.io/wunder/fuzzy-alpine-varnish
     ports:
-      8080:80
+      - 8080:80
     environment:
       DNSDOCK_ALIAS: wundertest.docker
       VARNISH_BACKEND_HOST: backend.app


### PR DESCRIPTION
This small patch fixes orchestration, which was broken due to bad yml in the docker-compose.yml file.