### PR TITLE
moved project ops to the initializer environment

### DIFF
--- a/.radi/environments/initializer/project.yml
+++ b/.radi/environments/initializer/project.yml
@@ -6,4 +6,5 @@ Components:
       - config
       - setting
       - command
+      - project
       - security

--- a/.radi/init.yml
+++ b/.radi/init.yml
@@ -526,6 +526,7 @@
           - config
           - setting
           - command
+          - project
           - security
         
 - Type: File
@@ -538,7 +539,6 @@
         Implementations:
           - config
           - setting
-          - project
           - security
     
       # Also use the local API for commands and orchestration

--- a/.radi/project.yml
+++ b/.radi/project.yml
@@ -5,7 +5,6 @@ Components:
     Implementations:
       - config
       - setting
-      - project
       - security
 
   # Also use the local API for commands and orchestration


### PR DESCRIPTION
This patch moves all of the project related operations to the `--environment initializer`.

The following options are now only available in that env:

```
   local:
     local.project.init, project.init          Initialize the current project path as a radi project [authorization required]
     local.project.create, project.create      Create a new local project from a yml templating source. [authorization required]
     local.project.generate, project.generate  Create a yml template from the current project [authorization required]
```


Note that this does not affect the case where the project has not been radified yet.

This just makes the UI leaner.