### PR TITLE
Fix second run radify

### DIFF
--- a/.radi/tools/wundertools/radify.sh
+++ b/.radi/tools/wundertools/radify.sh
@@ -128,7 +128,11 @@ for INITURL in $INIT_PATHS; do
 	sed -i -e "s/\%PORTBASE\%/${PORTBASE}/g" "${TMPFILE}"
 
 	echo "  --> Running template init:"
-	radi local.project.create --project.create.source "${TMPFILE}"
+	(
+		# the environment flag only makes sense when the prject has already been radified once
+		# but it doesn't break the 1st time case.
+		radi --environment="initializer" local.project.create --project.create.source "${TMPFILE}"
+	)
 
 	rm "${TMPFILE}"
 

--- a/.radi/tools/wundertools/radify.sh
+++ b/.radi/tools/wundertools/radify.sh
@@ -168,7 +168,7 @@ case "$YNBUILD" in
 		echo " "
 
 		(
-			radi --environment=initializer initialize -- --run-buildsh
+			radi --environment="initializer" initialize -- --run-buildsh
 		)
 
 		;;


### PR DESCRIPTION
This should fix https://github.com/wunderkraut/radi-project-wundertoolswrapper/issues/21

This patch makes all radi commands run in the radify script use the `--environment="initializer"` environment.

While this env may not exist on the first run, radi doesn't complain about it yet.